### PR TITLE
Create blocks for inputs and outputs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,7 +38,7 @@ There are many ways to set the `OPENAI_API_KEY` both securely and insecurely. Le
 
 :::
 
-## Your First Soccer Game ⚽️
+## Your First Soccer Game ⚽️ {#intro-example}
 
 Let's play a game of soccer. We'll write a function to flip a coin to determine who gets the first move. The assistant gets to be the referee.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import { OutputBlock } from "@site/src/components/cell";
+
 # Get Started
 
 With ChatLab, you can augment Large Language Models _with computational powers_ quickly.
@@ -36,7 +38,9 @@ There are many ways to set the `OPENAI_API_KEY` both securely and insecurely. Le
 
 :::
 
-## First Example ⚽️
+## Your First Soccer Game ⚽️
+
+Let's play a game of soccer. We'll write a function to flip a coin to determine who gets the first move. The assistant gets to be the referee.
 
 ```python cell executionCount=1
 from chatlab import system, Conversation, user
@@ -46,29 +50,32 @@ def flip_a_coin():
     '''Returns heads or tails'''
     return random.choice(['heads', 'tails'])
 
+# Setup the conversation by writing an initial screenplay
+game_intro = '''
+## INT. SOCCER FIELD - DAY
+
+**REF**, an experienced official with a firm command of the ⚽️ game, steps forward holding a shining silver coin. The coin that will determine the first move in the game. The home team captain steps up.
+'''
+
 conversation = Conversation(
   system("Form responses in Markdown and use emojis."),
-  system(
-      "## INT. SOCCER FIELD - DAY\n\n"
-      "**REF**, an experienced official with a firm command of the ⚽️ game, "
-      "steps forward holding a shining silver coin. The coin that will "
-      "determine the first move in the game. The home team captain steps up."
-  )
+  system(game_intro),
 )
 conversation.register(flip_a_coin)
 
 conversation.submit("**Kai**: We call tails.")
 ```
 
-<details style={{
-  background: '#DDE6ED',
-  color: '#27374D',
-  padding: '.5rem 1rem',
-  borderRadius: '5px',
-}}>
+<OutputBlock count="1">
+  <details style={{
+    background: '#DDE6ED',
+    color: '#27374D',
+    padding: '.5rem 1rem',
+    borderRadius: '5px',
+  }}>
 
-<summary>&nbsp;𝑓&nbsp; Ran `flip_a_coin`
-</summary>
+  <summary>&nbsp;𝑓&nbsp; Ran `flip_a_coin`
+  </summary>
 
 Input:
 
@@ -82,30 +89,36 @@ Output:
 "tails"
 ```
 
-</details>
+  </details>
 
-> **REF**: It's tails! The first move goes to the home team. Good luck to both teams! Let's begin the game! ⚽️👍🏼
+**REF**: It's tails! The first move goes to the home team. Good luck to both teams! Let's begin the game! ⚽️👍🏼
+</OutputBlock>
 
 ### Roles of a Conversation
 
 To understand what's going on, let's break down the individual `Message`s from `conversation.messages`:
 
-```json
-[{'role': 'system', 'content': 'Form responses in Markdown and use emojis.'},
- {'role': 'system',
-  'content': '## INT. SOCCER FIELD - DAY\n\n**REF**, an experienced official with a firm command of the ⚽️ game, steps forward holding a shining silver coin. The coin that will determine the first move in the game. The home team captain steps up.'},
- {'role': 'user', 'content': '**Kai**: We call tails.'},
- {'role': 'assistant',
-  'content': None,
-  'function_call': {'name': 'flip_a_coin', 'arguments': '{}'}},
- {'role': 'function', 'content': 'tails', 'name': 'flip_a_coin'},
- {'role': 'assistant',
-  'content': 'It\'s tails! The first move goes to the home team. Good luck to both teams! Let\'s begin the game! ⚽️👍🏼',
-  'function_call': None}
-]
+```python cell executionCount=2
+conversation.messages
 ```
 
-<!-- Note: the assistant is the AI, system is a message only the AI can see -- it's like a facilitator, user is obviously a user -->
+<OutputBlock count="2">
+
+```json mediaType=text/plain
+{ role: "system", content: "Form responses in Markdown and use emojis." },
+
+{ role: "system", content: "## INT. SOCCER FIELD - DAY\n\n**REF**, an experienced official with a firm command of the ⚽️ game, steps forward holding a shining silver coin. The coin that will determine the first move in the game. The home team captain steps up." },
+
+{ role: "user", content: "**Kai**: We call tails." },
+
+{ role: "assistant", content: None, function_call: { name: "flip_a_coin", arguments: "{}" }, },
+
+{ role: "function", content: "tails", name: "flip_a_coin" },
+
+{ role: "assistant", content: "It's tails! The first move goes to the home team. Good luck to both teams! Let's begin the game! ⚽️👍🏼", function_call: None, },
+```
+
+</OutputBlock>
 
 The four roles in a conversation are:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,7 +38,7 @@ There are many ways to set the `OPENAI_API_KEY` both securely and insecurely. Le
 
 :::
 
-## Your First Soccer Game ⚽️ {#intro-example}
+## Your First Soccer Game ⚽️ {#first-example}
 
 Let's play a game of soccer. We'll write a function to flip a coin to determine who gets the first move. The assistant gets to be the referee.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,7 +38,7 @@ There are many ways to set the `OPENAI_API_KEY` both securely and insecurely. Le
 
 ## First Example ⚽️
 
-```python
+```python cell executionCount=1
 from chatlab import system, Conversation, user
 import random
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
         "@mdx-js/react": "^1.6.22",
+        "classnames": "^2.3.2",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
@@ -4580,6 +4581,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -15988,6 +15994,11 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw=="
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/core": "2.4.1",
     "@docusaurus/preset-classic": "2.4.1",
     "@mdx-js/react": "^1.6.22",
+    "classnames": "^2.3.2",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/src/components/cell/blocks.tsx
+++ b/src/components/cell/blocks.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import styles from "./styles.module.css";
+import classNames from "classnames";
+
+import ExecutionCount from "./execution-count";
+
+type Props = {
+  count: number | string;
+  children: React.ReactNode;
+  type: "input" | "output";
+};
+
+const Block = ({ count, children, type }) => {
+  const contentWrapperClass = classNames(styles.cellContentWrapper, {
+    // We rely on the fact that the <CodeBlock /> component already has
+    // padding, so we don't add any here.
+    // [styles.cellContentWrapperInput]: type === "input",
+    [styles.cellContentWrapperOutput]: type === "output",
+  });
+
+  return (
+    <div className={styles.cellWrapper}>
+      <ExecutionCount count={count} type={type} />
+      <div className={contentWrapperClass}>{children}</div>
+    </div>
+  );
+};
+
+export const InputBlock = (props) => <Block type="input" {...props} />;
+export const OutputBlock = (props) => <Block type="output" {...props} />;
+
+export default Block;

--- a/src/components/cell/execution-count.tsx
+++ b/src/components/cell/execution-count.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styles from "./styles.module.css";
+import classNames from "classnames";
+
+type Props = {
+  count: number | string;
+  type: "input" | "output";
+};
+
+const ExecutionCount: React.FC<Props> = ({ count, type }) => {
+  // If count is not a number, return a [ ]
+  let counterText = "[ ]:";
+  if (typeof count === "number" || typeof count === "string") {
+    counterText = `[${count}]:`;
+  }
+
+  const executionCountClass = classNames(styles.executionCount, {
+    [styles.executionCountInput]: type === "input",
+    [styles.executionCountOutput]: type === "output",
+  });
+
+  return <div className={executionCountClass}>{counterText}</div>;
+};
+
+export default ExecutionCount;

--- a/src/components/cell/index.tsx
+++ b/src/components/cell/index.tsx
@@ -1,0 +1,4 @@
+import ExecutionCount from "./execution-count";
+import { InputBlock, OutputBlock } from "./blocks";
+
+export { ExecutionCount, InputBlock, OutputBlock };

--- a/src/components/cell/styles.module.css
+++ b/src/components/cell/styles.module.css
@@ -1,0 +1,54 @@
+.executionCount {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  color: #a7a7a7;
+  font-size: var(--ifm-code-font-size);
+  margin-top: var(--ifm-pre-padding);
+  margin-right: var(--ifm-pre-padding);
+  line-height: var(--ifm-pre-line-height);
+  min-width: 3rem;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  /* user-select: none; */
+}
+
+.cellWrapper {
+  display: flex;
+  align-items: flex-start;
+  /* padding: 1rem; */
+}
+
+.cellContentWrapper {
+  flex-grow: 1;
+  overflow: auto;
+}
+
+.cellContentWrapperOutput {
+  /* padding: var(--ifm-pre-padding); */
+  padding-top: var(--ifm-pre-padding);
+
+  color: var(--ifm-font-color-base);
+  background-color: var(--ifm-background-color);
+
+  --prism-background-color: var(--ifm-background-color);
+  --prism-color: var(--ifm-font-color-base);
+}
+
+.cellContentWrapperOutput pre {
+  padding: 0;
+
+  /* color: var(--ifm-font-color-base); */
+  background-color: var(--ifm-background-color);
+
+  --prism-background-color: var(--ifm-background-color);
+  --prism-color: var(--ifm-font-color-base);
+}
+
+.executionCountInput {
+  color: #307fc1;
+}
+
+.executionCountOutput {
+  color: #bf5b3d;
+}

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,48 +1,23 @@
 import React from "react";
 import CodeBlock from "@theme-original/CodeBlock";
 
-const ExecutionCount = ({ count }) => {
-  // If count is not a number, return a [ ]
-  let counterText = "[ ]:";
-  if (typeof count === "number" || typeof count === "string") {
-    counterText = `[${count}]:`;
-  }
-  return (
-    <div
-      style={{
-        fontFamily:
-          'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-        color: "#a7a7a7",
-        letterSpacing: "normal",
-        lineHeight: "1rem",
-        fontSize: "1rem",
-        marginTop: "1rem",
-        marginRight: "1rem",
-        minWidth: "3rem",
-        textAlign: "right",
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        userSelect: "none",
-      }}
-    >
-      {counterText}
-    </div>
-  );
-};
+import { InputBlock } from "@site/src/components/cell";
 
 export default function CodeBlockWrapper(props) {
+  if (props.mediaType == "text/plain") {
+    console.log("We got em");
+    console.log(props);
+    // return <CodeBlock {...props} style={{ backgroundColor: "green" }} />;
+    return <pre>{props.children}</pre>;
+  }
+
   if (!props.cell) {
     return <CodeBlock {...props} />;
   }
 
-  console.log(props);
-
   return (
-    <div style={{ display: "flex", alignItems: "flex-start", padding: "1rem" }}>
-      <ExecutionCount count={props.executionCount} />
-      <div style={{ flexGrow: 0, overflow: "auto" }}>
-        <CodeBlock {...props} />
-      </div>
-    </div>
+    <InputBlock count={props.executionCount}>
+      <CodeBlock {...props} />
+    </InputBlock>
   );
 }

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,48 @@
+import React from "react";
+import CodeBlock from "@theme-original/CodeBlock";
+
+const ExecutionCount = ({ count }) => {
+  // If count is not a number, return a [ ]
+  let counterText = "[ ]:";
+  if (typeof count === "number" || typeof count === "string") {
+    counterText = `[${count}]:`;
+  }
+  return (
+    <div
+      style={{
+        fontFamily:
+          'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        color: "#a7a7a7",
+        letterSpacing: "normal",
+        lineHeight: "1rem",
+        fontSize: "1rem",
+        marginTop: "1rem",
+        marginRight: "1rem",
+        minWidth: "3rem",
+        textAlign: "right",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        userSelect: "none",
+      }}
+    >
+      {counterText}
+    </div>
+  );
+};
+
+export default function CodeBlockWrapper(props) {
+  if (!props.cell) {
+    return <CodeBlock {...props} />;
+  }
+
+  console.log(props);
+
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", padding: "1rem" }}>
+      <ExecutionCount count={props.executionCount} />
+      <div style={{ flexGrow: 0, overflow: "auto" }}>
+        <CodeBlock {...props} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This will help notebook-focused documentation keep docs separate from inputs and outputs, some of which contain markdown themselves.

![image](https://github.com/rgbkrk/chatlab-docs/assets/836375/9bcdcb56-c41e-4705-9718-e13f6fd0dd17)