### PR TITLE
Process output blocks

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -42,7 +42,7 @@ There are many ways to set the `OPENAI_API_KEY` both securely and insecurely. Le
 
 Let's play a game of soccer. We'll write a function to flip a coin to determine who gets the first move. The assistant gets to be the referee.
 
-```python cell executionCount=1
+```python cell count=1
 from chatlab import system, Conversation, user
 import random
 
@@ -98,13 +98,11 @@ Output:
 
 To understand what's going on, let's break down the individual `Message`s from `conversation.messages`:
 
-```python cell executionCount=2
+```python cell count=2
 conversation.messages
 ```
 
-<OutputBlock count="2">
-
-```json mediaType=text/plain
+```js output count=2
 { role: "system", content: "Form responses in Markdown and use emojis." },
 
 { role: "system", content: "## INT. SOCCER FIELD - DAY\n\n**REF**, an experienced official with a firm command of the ⚽️ game, steps forward holding a shining silver coin. The coin that will determine the first move in the game. The home team captain steps up." },
@@ -118,8 +116,6 @@ conversation.messages
 { role: "assistant", content: "It's tails! The first move goes to the home team. Good luck to both teams! Let's begin the game! ⚽️👍🏼", function_call: None, },
 ```
 
-</OutputBlock>
-
 The four roles in a conversation are:
 
 - `system` - The system is like a narrator to inform the AI of the context of the conversation. They set the scene and steer the model.
@@ -131,15 +127,19 @@ The four roles in a conversation are:
 
 Any function with typed arguments can be registered quickly in a conversation. Registering the function will allow the `assistant` to call it during the conversation.
 
-```python
+```python cell count=3
 conversation.register(flip_a_coin)
 ```
 
-```json
+```json output count=3
 {
   "name": "flip_a_coin",
   "description": "Returns heads or tails",
-  "parameters": { "type": "object", "properties": {}, "required": [] }
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
 }
 ```
 
@@ -147,13 +147,15 @@ Under the hood, ChatLab inspects your function and generates a JSON Schema for i
 
 ### Submitting Messages
 
-Every time you run `submit`, ChatLab sends the conversation to the assistant and returns the response. The response is a `Message` with the `role` of `assistant`.
+Every time you run `submit`, ChatLab sends the conversation to the assistant and returns the response. The response is a `Message` with the `role` of `assistant`. If we wanted to create this message ourselves, we can run:
 
-```python
-conversation.submit("**Kai**: We call tails.")
+```python cell count=4
+from chatlab.messaging import assistant_function_call
+
+assistant_function_call("flip_a_coin", arguments="{}")
 ```
 
-```json
+```json output count=4
 {
   "role": "assistant",
   "content": null,
@@ -167,7 +169,13 @@ The `content` is `null` because the assistant has decided to call a function. Th
 
 When the assistant calls a function, `chatlab` sends back a `Message` with the role `function`. The `content` is the return value of the function.
 
-```json
+```python cell count=5
+from chatlab.messaging import function_result
+
+function_result(content="tails", name="flip_a_coin")
+```
+
+```json output count=5
 {
   "role": "function",
   "content": "tails",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
         "@mdx-js/react": "^1.6.22",
-        "classnames": "^2.3.2",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
@@ -4581,11 +4580,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -15994,11 +15988,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw=="
-    },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@docusaurus/core": "2.4.1",
     "@docusaurus/preset-classic": "2.4.1",
     "@mdx-js/react": "^1.6.22",
-    "classnames": "^2.3.2",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/src/components/cell/blocks.tsx
+++ b/src/components/cell/blocks.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styles from "./styles.module.css";
-import classNames from "classnames";
+import clsx from "clsx";
 
 import ExecutionCount from "./execution-count";
 
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const Block = ({ count, children, type }) => {
-  const contentWrapperClass = classNames(styles.cellContentWrapper, {
+  const contentWrapperClass = clsx(styles.cellContentWrapper, {
     // We rely on the fact that the <CodeBlock /> component already has
     // padding, so we don't add any here.
     // [styles.cellContentWrapperInput]: type === "input",

--- a/src/components/cell/execution-count.tsx
+++ b/src/components/cell/execution-count.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import clsx from "clsx";
 import React from "react";
 
 import styles from "./styles.module.css";
@@ -15,7 +15,7 @@ const ExecutionCount: React.FC<Props> = ({ count, type }) => {
     counterText = `[${count}]:`;
   }
 
-  const executionCountClass = classNames(styles.executionCount, {
+  const executionCountClass = clsx(styles.executionCount, {
     [styles.executionCountInput]: type === "input",
     [styles.executionCountOutput]: type === "output",
   });

--- a/src/components/cell/execution-count.tsx
+++ b/src/components/cell/execution-count.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import styles from "./styles.module.css";
 import classNames from "classnames";
+import React from "react";
+
+import styles from "./styles.module.css";
 
 type Props = {
   count: number | string;

--- a/src/components/cell/styles.module.css
+++ b/src/components/cell/styles.module.css
@@ -25,20 +25,7 @@
 }
 
 .cellContentWrapperOutput {
-  /* padding: var(--ifm-pre-padding); */
-  padding-top: var(--ifm-pre-padding);
-
-  color: var(--ifm-font-color-base);
-  background-color: var(--ifm-background-color);
-
-  --prism-background-color: var(--ifm-background-color);
-  --prism-color: var(--ifm-font-color-base);
-}
-
-.cellContentWrapperOutput pre {
-  padding: 0;
-
-  /* color: var(--ifm-font-color-base); */
+  padding-top: 1rem;
   background-color: var(--ifm-background-color);
 
   --prism-background-color: var(--ifm-background-color);

--- a/src/theme/CodeBlock/Container/index.js
+++ b/src/theme/CodeBlock/Container/index.js
@@ -1,0 +1,38 @@
+import React from "react";
+import clsx from "clsx";
+import { ThemeClassNames, usePrismTheme } from "@docusaurus/theme-common";
+import { getPrismCssVariables } from "@docusaurus/theme-common/internal";
+import styles from "./styles.module.css";
+export default function CodeBlockContainer({ as: As, ...props }) {
+  const prismTheme = usePrismTheme();
+  let prismCssVariables = getPrismCssVariables(prismTheme);
+
+  let className = clsx(
+    props.className,
+    styles.codeBlockContainer,
+    ThemeClassNames.common.codeBlock
+  );
+
+  // HACK: Detect if this is an output block, and if so, remove the inline styles
+  if (props.className.includes("chatlab-cell-output")) {
+    // We want output to render without:
+    // - The inline style for background color added to the element
+    // - The inline style for color added to the element
+    // - The box shadow
+    prismCssVariables = {};
+    className = clsx(
+      props.className,
+      styles.outputBlockContainer,
+      ThemeClassNames.common.codeBlock
+    );
+  }
+
+  return (
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...props}
+      style={prismCssVariables}
+      className={className}
+    />
+  );
+}

--- a/src/theme/CodeBlock/Container/styles.module.css
+++ b/src/theme/CodeBlock/Container/styles.module.css
@@ -1,0 +1,14 @@
+.codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  margin-bottom: var(--ifm-leading);
+  box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
+}
+
+.outputBlockContainer {
+  /** To make the output look lined up like it would
+  in the notebook, override the CSS variable for pre padding */
+  --ifm-pre-padding: 0rem;
+  margin-bottom: var(--ifm-leading);
+}

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import clsx from "clsx";
 import React from "react";
 
 import { InputBlock, OutputBlock } from "@site/src/components/cell";
@@ -36,7 +36,7 @@ export default function CodeBlockWrapper(props) {
   // Handle basic plaintext outputs in a friendly way for JSON outputs
   if (props.output) {
     // HACK: Allow the CodeBlockContainer to know this is an output block
-    const className = classNames(props.className, "chatlab-cell-output");
+    const className = clsx(props.className, "chatlab-cell-output");
 
     return (
       <OutputBlock count={count}>

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,19 +1,52 @@
+import classNames from "classnames";
 import React from "react";
+
+import { InputBlock, OutputBlock } from "@site/src/components/cell";
 import CodeBlock from "@theme-original/CodeBlock";
 
-import { InputBlock } from "@site/src/components/cell";
-
 export default function CodeBlockWrapper(props) {
-  if (props.mediaType == "text/plain") {
-    return <pre>{props.children}</pre>;
-  }
+  //
+  // This CodeBlockWrapper introduces two new types of markdown code blocks,
+  // to mimic Jupyter Notebook frontend cells:
+  //
+  // - Input Blocks
+  // - Output Blocks
+  //
+  // To use them, simply add the following to your markdown:
+  //
+  // ```python cell
+  // d = {"foo": "bar"}
+  // d
+  // ```
+  //
+  // ```json output
+  // {
+  //   "foo": "bar"
+  // }
+  // ```
+  //
 
-  if (!props.cell) {
+  // Regular Code Blocks
+  if (!props.cell && !props.output) {
     return <CodeBlock {...props} />;
   }
 
+  let count = props.count || props.executionCount || props.execution_count;
+
+  // Handle basic plaintext outputs in a friendly way for JSON outputs
+  if (props.output) {
+    // HACK: Allow the CodeBlockContainer to know this is an output block
+    const className = classNames(props.className, "chatlab-cell-output");
+
+    return (
+      <OutputBlock count={count}>
+        <CodeBlock {...props} className={className} />
+      </OutputBlock>
+    );
+  }
+
   return (
-    <InputBlock count={props.executionCount}>
+    <InputBlock count={count}>
       <CodeBlock {...props} />
     </InputBlock>
   );


### PR DESCRIPTION
Two ways to do Output Blocks now:

## Component: `<OutputBlock count="1">`

``````mdx
<OutputBlock count="1">
  <details style={{
    background: '#DDE6ED',
    color: '#27374D',
    padding: '.5rem 1rem',
    borderRadius: '5px',
  }}>
  
  <summary>&nbsp;𝑓&nbsp; Ran `flip_a_coin`
  </summary>
  
  Input:
  
  ```json
  {}
  ```
  
  Output:
  
  ```json
  "tails"
  ```
  
  </details>

**REF**: It's tails! The first move goes to the home team. Good luck to both teams! Let's begin the game! ⚽️👍🏼
</OutputBlock>
``````

![image](https://github.com/rgbkrk/chatlab-docs/assets/836375/2b60a621-f5dc-46c8-9a1f-ef4388cee6d4)

## Markdown code blocks tagged with `output count={execution_count}`

``````markdown
```json output count=3
{
  "name": "flip_a_coin",
  "description": "Returns heads or tails",
  "parameters": {
    "type": "object",
    "properties": {},
    "required": []
  }
}
```
``````

![image](https://github.com/rgbkrk/chatlab-docs/assets/836375/46fddc56-816f-41dd-b076-13983c3fddba)


